### PR TITLE
Fixed webpack babel compile issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["@babel/transform-runtime"] 
+}
+


### PR DESCRIPTION
This pull request is based on #1 
In addition, this pull request fixes issue of `regeneratorRuntime` not being defined when running `npm run start-http`.
Original stack overflow [link](https://stackoverflow.com/questions/53558916/babel-7-referenceerror-regeneratorruntime-is-not-defined) attached for reference.